### PR TITLE
Make series a deep watcher

### DIFF
--- a/src/vue3-apexcharts.js
+++ b/src/vue3-apexcharts.js
@@ -219,7 +219,8 @@ const vueApexcharts = defineComponent({
         } else {
           chart.value.updateSeries(props.series);
         }
-      }
+      },
+      {deep: true}
     );
 
     watch(


### PR DESCRIPTION
Suppose you have some computed properties like so,

const myvalues = computed(()=> store.state.myvalues)

const series = computed(() => [
  {
    name: "series-1",
    data: myvalues.value
  }
]);

The update watcher needs to be a deep watcher to see changes to data.