### PR TITLE
Fix chart not updating when using compositions api Vue 3

### DIFF
--- a/demo/.eslintignore
+++ b/demo/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+../**

--- a/demo/public/index.html
+++ b/demo/public/index.html
@@ -4,8 +4,6 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>
     <noscript>

--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -7,6 +7,7 @@
 
     <div class="container">
       <LineChart />
+      <LineChartCompositionApi />
       <AreaChart />
       <BarChart />
       <MixedChart />
@@ -20,6 +21,7 @@
 import AreaChart from "@/components/AreaChart.vue";
 import BarChart from "@/components/BarChart.vue";
 import LineChart from "@/components/LineChart.vue";
+import LineChartCompositionApi from "@/components-composition-api/LineChart.vue";
 import MixedChart from "@/components/MixedChart.vue";
 import DonutChart from "@/components/DonutChart.vue";
 
@@ -30,7 +32,8 @@ export default {
     BarChart,
     DonutChart,
     LineChart,
-    MixedChart
+    MixedChart,
+    LineChartCompositionApi,
   },
   data: function() {
     return {};

--- a/demo/src/components-composition-api/LineChart.vue
+++ b/demo/src/components-composition-api/LineChart.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="example">
+    <h4>Composition API Line chart</h4>
+    <apexchart
+      width="500"
+      height="350"
+      type="line"
+      :options="chartOptions"
+      :series="series"
+    ></apexchart>
+    <div>
+      <button @click="updateChart">Update!</button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { defineComponent, ref } from 'vue';
+
+export default defineComponent({
+  name: 'LineExample-CompositionApi',
+  setup() {
+    const chartOptions = ref({
+      xaxis: {
+        type: 'datetime',
+        categories: [
+          '01/01/2003',
+          '02/01/2003',
+          '03/01/2003',
+          '04/01/2003',
+          '05/01/2003',
+          '06/01/2003',
+          '07/01/2003',
+          '08/01/2003',
+        ],
+      },
+    });
+    const series = ref([
+      {
+        name: 'Series A',
+        data: [30, 40, 45, 50, 49, 60, 70, 91],
+      },
+      {
+        name: 'Series B',
+        data: [23, 43, 54, 12, 44, 52, 32, 11],
+      },
+    ]);
+    function generateDayWiseTimeSeries(baseval, count, yrange) {
+      let i = 0;
+      const newSeries = [];
+      while (i < count) {
+        const x = baseval;
+        const y = Math.floor(Math.random() * (yrange.max - yrange.min + 1)) + yrange.min;
+
+        newSeries.push([x, y]);
+        // eslint-disable-next-line no-param-reassign
+        baseval += 86400000;
+        // eslint-disable-next-line no-plusplus
+        i++;
+      }
+      return newSeries;
+    }
+    function updateChart() {
+      const newSeries = [
+        {
+          name: 'South',
+          data: generateDayWiseTimeSeries(new Date('11 Feb 2017').getTime(), 20, {
+            min: 10,
+            max: 60,
+          }),
+        },
+        {
+          name: 'North',
+          data: generateDayWiseTimeSeries(new Date('11 Feb 2017').getTime(), 20, {
+            min: 10,
+            max: 20,
+          }),
+        },
+
+        {
+          name: 'Central',
+          data: generateDayWiseTimeSeries(new Date('11 Feb 2017').getTime(), 20, {
+            min: 10,
+            max: 15,
+          }),
+        },
+      ];
+
+      series.value = newSeries;
+    }
+
+    return { chartOptions, series, updateChart };
+  },
+});
+</script>

--- a/demo/src/components/LineChart.vue
+++ b/demo/src/components/LineChart.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="example">
+    <h4>Options API Line chart</h4>
     <apexchart
       width="500"
       height="350"

--- a/src/vue3-apexcharts.js
+++ b/src/vue3-apexcharts.js
@@ -8,6 +8,7 @@ import {
 	watch,
 	onBeforeMount,
 	nextTick,
+  toRefs,
 } from "vue";
 import ApexCharts from "apexcharts";
 
@@ -241,8 +242,9 @@ const vueApexcharts = defineComponent({
 			destroy();
 		});
 
+    const reactiveProps = toRefs(props);
 		watch(
-			() => props.options,
+			reactiveProps.options,
 			() => {
 				if (!chart.value && props.options) {
 					init();
@@ -253,7 +255,7 @@ const vueApexcharts = defineComponent({
 		);
 
 		watch(
-			() => props.series,
+			reactiveProps.series,
 			() => {
 				if (!chart.value && props.series) {
 					init();
@@ -264,21 +266,21 @@ const vueApexcharts = defineComponent({
 		);
 
 		watch(
-			() => props.type,
+			reactiveProps.type,
 			() => {
 				refresh();
 			}
 		);
 
 		watch(
-			() => props.width,
+			reactiveProps.width,
 			() => {
 				refresh();
 			}
 		);
 
 		watch(
-			() => props.height,
+			reactiveProps.height,
 			() => {
 				refresh();
 			}


### PR DESCRIPTION
Issue:
Vue Composition API does not observe that there are changes to pure arrays, which results in no reactive rendering when series array changes.

This fix uses the `toRefs` method to make all props reactive which allows for using ref arrays (in composition api) and data arrays (in options api) to reactively update chart data.

A bit badly explained, please ask if there are anything I can explain better.

How to test:
1. Pull project
2. Run in terminal:
- `yarn install;  yarn build; cd demo; yarn start`
- Open `localhost:8081/vue3-apexcharts` in browser