### PR TITLE
avoids re-initialization of ApexCharts

### DIFF
--- a/src/vue3-apexcharts.js
+++ b/src/vue3-apexcharts.js
@@ -116,6 +116,10 @@ const vueApexcharts = defineComponent({
 
     const init = async () => {
       await nextTick();
+      
+      if (chart.value) {
+			  return;
+      }
 
       const newOptions = {
         chart: {


### PR DESCRIPTION
I found out that `init` method can be triggered twice when component gets mounted and series get updated very quickly after component got mounted. So I added a small check in the `init` method to double check if chart already exists.


Fixes #3 