### PR TITLE
fix: explicit "types" condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "private": false,
   "exports": {
     ".": {
+      "types": "./typings/vue-apexcharts.d.ts",
       "import": "./dist/vue3-apexcharts.js",
       "require": "./dist/vue3-apexcharts.umd.cjs"
     }


### PR DESCRIPTION
When using package.json "exports" and "import" / "types" have different paths, explicit "types" condition is needed.

Ref: [packagejson-exports](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports)

fix #95
