### PR TITLE
Ensure that events defined in chart options are called too.

### DIFF
--- a/src/vue3-apexcharts.js
+++ b/src/vue3-apexcharts.js
@@ -132,10 +132,17 @@ const vueApexcharts = defineComponent({
       };
 
       // emit events to the parent component
-      // to allow for two-way data binding
+      // to allow for two-way data binding, while
+      // also allowing chart options to define callbacks
+      const optionsEvents = props.options.chart.events;
       events.forEach(event => {
         let callback = (...args) => emit(event, ...args); // args => chartContext, options
-        newOptions.chart.events[event] = callback;
+        newOptions.chart.events[event] = (...args) => {
+          callback(...args);
+          if (optionsEvents && optionsEvents.hasOwnProperty(event)) {
+            optionsEvents[event](...args);
+          }
+        };
       });
 
       const config = extend(props.options, newOptions);


### PR DESCRIPTION
Currently vue3-apexcharts defines the same callback for each of apexcharts events, and those callbacks just calls "emit()" so that the e.g. `@mousemove='some-handler'`-style definition works:

https://github.com/apexcharts/vue3-apexcharts/blob/02b0a1af917c78d791087a6fc6dbad379e04dbf9/src/vue3-apexcharts.js#L137-L138

But the docs don't mention this limitation anywhere, so most people unsuccessfully define events in the chart options like the apexcharts docs describe. 

This fix calls any defined events in the chart options after the `emit()` is called, so the chart options' events will work.

fix https://github.com/apexcharts/vue3-apexcharts/issues/20