### PR TITLE
fix: type prop in VueApexCharts typings

### DIFF
--- a/typings/vue-apexcharts.d.ts
+++ b/typings/vue-apexcharts.d.ts
@@ -6,21 +6,7 @@ export interface VueApexChartsComponentProps {
   readonly chart?: ApexCharts;
   // props
   options?: ApexOptions;
-  type?:
-    | "line"
-    | "area"
-    | "bar"
-    | "histogram"
-    | "pie"
-    | "donut"
-    | "radialBar"
-    | "rangeBar"
-    | "scatter"
-    | "bubble"
-    | "heatmap"
-    | "candlestick"
-    | "radar"
-    | "polarArea";
+  type?: NonNullable<ApexOptions['chart']>['type'];
   series: any;
   width?: string | number;
   height?: string | number;


### PR DESCRIPTION
Updated the 'type' prop to use NonNullable<ApexOptions['chart']>['type'] for improved type safety and maintainability.
E.g `treemap` was not in the current list.